### PR TITLE
.gitignore restored its state on April 28th

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 _site
 .sass-cache
 .jekyll-metadata
+/node_modules
+.DS_Store
+
+
+# ignore gulp-generated vendor files
+scss/lib


### PR DESCRIPTION
The code within .gitignore has been restored to its state before the commit of chriscjamison. This code was taken from a commit on April 28th.